### PR TITLE
docs: 更新 ACGURL 成员介绍

### DIFF
--- a/docs/members/3-ordinaryMembers/ACGURL.md
+++ b/docs/members/3-ordinaryMembers/ACGURL.md
@@ -40,4 +40,5 @@ layout: doc
 ###	Contact
 [QQ](https://wpa.qq.com/msgrd?v=3&uin=1485942570&site=qq&menu=yes&jumpflag=1)
 [Github](https://github.com/acgurl)
+[Linux Do](https://linux.do/u/acgurl)
 全天在线，消息秒回

--- a/docs/members/3-ordinaryMembers/ACGURL.md
+++ b/docs/members/3-ordinaryMembers/ACGURL.md
@@ -4,41 +4,40 @@ layout: doc
 
 # ACGURL
 
-![An image](https://github.com/acgurl.png)
+![An image](https://q1.qlogo.cn/g?b=qq&nk=1485942570&s=160)
 
-###  Age
-认真学习的一名**大学生**
+___
 
-###  Detail
-就读于中国传媒大学
-智能科学与技术专业
-
-###  Devices
-| Type | Description |
-| ----------- | ----------- |
-| Laptop | HONOR Win H7（i7-14650HX + RTX 5060 Laptop） |
-| Phone | HONOR Power2（12GB + 512GB） |
-| Server | 腾讯云2h2g轻量服务器 |
-
-###  Skills
--  **编程语言**
-  -  Bash  *已系统学习*
-  -  Python  *正在学*
-  -  HTML&CSS  *略微学过*
-  -  PHP  *略微学过*
-
-###  Hobby
--	GAME
-  -		原神
-  -		绝区零
-  -		崩坏：星穹铁道 *已退坑，账号已移交给同学*
-  -		舞萌DX *Rating: w3*
--	COLLECT
-	-	好用的软件
-	-	好用的网站
-
-###	Contact
-[QQ](https://wpa.qq.com/msgrd?v=3&uin=1485942570&site=qq&menu=yes&jumpflag=1)
-[Github](https://github.com/acgurl)
-[Linux Do](https://linux.do/u/acgurl)
+就读于中国传媒大学 · 智能科学与技术专业
 全天在线，消息秒回
+
+## 设备
+
+| 设备 | 配置 |
+| :--- | :--- |
+| 笔记本 | HONOR Win H7（i7-14650HX + RTX 5060 Laptop） |
+| 手机 | HONOR Power2（12GB + 512GB） |
+| 服务器 | 腾讯云 2H2G 轻量服务器 |
+
+## 技能
+
+![Static Badge](https://img.shields.io/badge/Bash-%E5%B7%B2%E7%B3%BB%E7%BB%9F%E5%AD%A6%E4%B9%A0?style=flat-square&logo=gnubash&logoColor=white&color=4EAA25)
+![Static Badge](https://img.shields.io/badge/Python-%E6%AD%A3%E5%9C%A8%E5%AD%A6?style=flat-square&logo=python&logoColor=white&color=3178C6)
+![Static Badge](https://img.shields.io/badge/HTML-%E7%95%A5%E5%BE%AE%E5%AD%A6%E8%BF%87?style=flat-square&logo=html5&logoColor=white&color=E34F26)
+![Static Badge](https://img.shields.io/badge/CSS-%E7%95%A5%E5%BE%AE%E5%AD%A6%E8%BF%87?style=flat-square&logo=css3&logoColor=white&color=1572B6)
+![Static Badge](https://img.shields.io/badge/PHP-%E7%95%A5%E5%BE%AE%E5%AD%A6%E8%BF%87?style=flat-square&logo=php&logoColor=white&color=777BB4)
+
+## 游戏
+
+| 游戏 | 状态 |
+| :--- | :--- |
+| 原神 | 在玩 |
+| 绝区零 | 在玩 |
+| 舞萌DX | 在玩 · Rating w3 |
+| 崩坏：星穹铁道 | 已退坑 · 账号已移交给同学 |
+
+## 联系
+
+- QQ：1485942570
+- [GitHub](https://github.com/acgurl)
+- [Linux Do](https://linux.do/u/acgurl)

--- a/docs/members/3-ordinaryMembers/ACGURL.md
+++ b/docs/members/3-ordinaryMembers/ACGURL.md
@@ -1,6 +1,9 @@
 ---
 layout: doc
 ---
+
+# ACGURL
+
 ![An image](https://github.com/acgurl.png)
 
 ###  Age
@@ -27,7 +30,9 @@ layout: doc
 ###  Hobby
 -	GAME
   -		原神
-  -		崩坏：星穹铁道
+  -		绝区零
+  -		崩坏：星穹铁道 *已退坑，账号已移交给同学*
+  -		舞萌DX *Rating: w3*
 -	COLLECT
 	-	好用的软件
 	-	好用的网站

--- a/docs/members/3-ordinaryMembers/ACGURL.md
+++ b/docs/members/3-ordinaryMembers/ACGURL.md
@@ -40,4 +40,4 @@ layout: doc
 ###	Contact
 [QQ](https://wpa.qq.com/msgrd?v=3&uin=1485942570&site=qq&menu=yes&jumpflag=1)
 [Github](https://github.com/acgurl)
-（不过估计我在线上的时间会很少）
+全天在线，消息秒回

--- a/docs/members/3-ordinaryMembers/wander@acgurl.link.md
+++ b/docs/members/3-ordinaryMembers/wander@acgurl.link.md
@@ -1,25 +1,20 @@
 ---
 layout: doc
 ---
-![An image](https://www.acgurl.link/upload/qlogo.jpg)
+![An image](https://github.com/acgurl.png)
 
 ###  Age
-认真学习的一名**高中生**
+认真学习的一名**大学生**
 
 ###  Detail
-现居高考大省河南
-就读于一所普通县级重点中学
-时间紧迫放假极少（平均一月休息4天）
-曾于正月初三于千里之外的湖南被告知明天返校
-
-###  Blog
-欢迎来玩，互加友链
-[ACGURL](https://www.acgurl.link)
+就读于中国传媒大学
+智能科学与技术专业
 
 ###  Devices
 | Type | Description |
 | ----------- | ----------- |
-| Personal Computer | 联想某不知名笔记本 |
+| Laptop | HONOR Win H7（i7-14650HX + RTX 5060 Laptop） |
+| Phone | HONOR Power2（12GB + 512GB） |
 | Server | 腾讯云2h2g轻量服务器 |
 
 ###  Skills
@@ -32,9 +27,7 @@ layout: doc
 ###  Hobby
 -	GAME
   -		原神
-  ![ys](https://api.acgurl.link/ysh.php?style=@.webp)
   -		崩坏：星穹铁道
-  ![xq](https://api.acgurl.link/xq.php?style=@.webp)
 -	COLLECT
 	-	好用的软件
 	-	好用的网站


### PR DESCRIPTION
## 变更内容

更新成员介绍页（原 `wander@acgurl.link.md`）。

### 名称与身份
- 成员名由 **wander@acgurl.link** 改为 **ACGURL**（文件重命名 + 页面标题 `# ACGURL`）
- 就读信息更新：中国传媒大学 · 智能科学与技术专业（原高中信息已过时）

### 内容清理
- 移除已废弃的博客区块与 `acgurl.link` 域名链接
- 清理失效图片（头像改用 GitHub 头像，删除 `acgurl.link` 游戏卡片图）

### 设备
- 新增 HONOR Win H7（i7-14650HX + RTX 5060 Laptop）
- 新增 HONOR Power2（12GB + 512GB）
- 保留腾讯云轻量服务器

### 游戏
- 新增：绝区零、舞萌DX（Rating: w3）
- 崩坏：星穹铁道 → 已退坑，账号已移交给同学

### 联系方式
- 新增 Linux Do：https://linux.do/u/acgurl
- 备注更新为「全天在线，消息秒回」
